### PR TITLE
Initial put update

### DIFF
--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -167,7 +167,7 @@ func DefaultListContact(ctx context.Context, db *gorm.DB) ([]*Contact, error) {
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateContact executes a basic gorm update call
+// DefaultCascadedUpdateContact clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (*Contact, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateContact")

--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -166,3 +166,19 @@ func DefaultListContact(ctx context.Context, db *gorm.DB) ([]*Contact, error) {
 	}
 	return pbResponse, nil
 }
+
+// DefaultUpdateContact executes a basic gorm update call
+func DefaultCascadedUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (*Contact, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateContact")
+	}
+	ormObj := ConvertContactToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertContactFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
+}

--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -141,7 +141,7 @@ func DefaultDeleteContact(ctx context.Context, in *Contact, db *gorm.DB) error {
 	return err
 }
 
-// DefaultListContact executes a basic gorm find call
+// DefaultListContact executes a gorm list call
 func DefaultListContact(ctx context.Context, db *gorm.DB) ([]*Contact, error) {
 	ormResponse := []ContactORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
@@ -167,7 +167,7 @@ func DefaultListContact(ctx context.Context, db *gorm.DB) ([]*Contact, error) {
 	return pbResponse, nil
 }
 
-// DefaultUpdateContact executes a basic gorm update call
+// DefaultCascadedUpdateContact executes a basic gorm update call
 func DefaultCascadedUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (*Contact, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateContact")

--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -167,18 +167,24 @@ func DefaultListContact(ctx context.Context, db *gorm.DB) ([]*Contact, error) {
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateContact clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (*Contact, error) {
+// DefaultStrictUpdateContact clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (*Contact, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateContact")
 	}
-	ormObj := ConvertContactToORM(*in)
+	ormObj, err := ConvertContactToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertContactFromORM(ormObj)
+	pbResponse, err := ConvertContactFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -3,21 +3,34 @@
 
 package example
 
-import context "context"
-import errors "errors"
-import gorm "github.com/jinzhu/gorm"
-import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
-import uuid "github.com/satori/go.uuid"
-import gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
-import time "time"
-import ptypes "github.com/golang/protobuf/ptypes"
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/infobloxopen/protoc-gen-gorm/types"
-import google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
-import google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
-import _ "github.com/golang/protobuf/ptypes/timestamp"
+import (
+	context "context"
+	errors "errors"
+
+	gorm "github.com/jinzhu/gorm"
+
+	"github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
+	ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
+	uuid "github.com/satori/go.uuid"
+
+	gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
+
+	time "time"
+
+	ptypes "github.com/golang/protobuf/ptypes"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	fmt "fmt"
+
+	math "math"
+
+	_ "github.com/infobloxopen/protoc-gen-gorm/types"
+
+	google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
+
+	_ "github.com/golang/protobuf/ptypes/timestamp"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -285,7 +298,7 @@ func DefaultDeleteTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) err
 	return err
 }
 
-// DefaultListTestTypes executes a basic gorm find call
+// DefaultListTestTypes executes a gorm list call
 func DefaultListTestTypes(ctx context.Context, db *gorm.DB) ([]*TestTypes, error) {
 	ormResponse := []TestTypesORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
@@ -306,7 +319,7 @@ func DefaultListTestTypes(ctx context.Context, db *gorm.DB) ([]*TestTypes, error
 	return pbResponse, nil
 }
 
-// DefaultUpdateTestTypes executes a basic gorm update call
+// DefaultCascadedUpdateTestTypes executes a basic gorm update call
 func DefaultCascadedUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) (*TestTypes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTestTypes")
@@ -383,8 +396,8 @@ func DefaultDeleteTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) e
 	return err
 }
 
-// DefaultListTypeWithID executes a basic gorm find call
-func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithId, error) {
+// DefaultListTypeWithID executes a gorm list call
+func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithID, error) {
 	ormResponse := []TypeWithIDORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
 	if err != nil {
@@ -404,7 +417,7 @@ func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithId, err
 	return pbResponse, nil
 }
 
-// DefaultUpdateTypeWithID executes a basic gorm update call
+// DefaultCascadedUpdateTypeWithID executes a basic gorm update call
 func DefaultCascadedUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeWithID")
@@ -501,8 +514,8 @@ func DefaultDeleteMultitenantTypeWithID(ctx context.Context, in *MultitenantType
 	return err
 }
 
-// DefaultListMultitenantTypeWithID executes a basic gorm find call
-func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*MultitenantTypeWithId, error) {
+// DefaultListMultitenantTypeWithID executes a gorm list call
+func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*MultitenantTypeWithID, error) {
 	ormResponse := []MultitenantTypeWithIDORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
 	if err != nil {
@@ -527,7 +540,7 @@ func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*Mult
 	return pbResponse, nil
 }
 
-// DefaultUpdateMultitenantTypeWithID executes a basic gorm update call
+// DefaultCascadedUpdateMultitenantTypeWithID executes a basic gorm update call
 func DefaultCascadedUpdateMultitenantTypeWithID(ctx context.Context, in *MultitenantTypeWithId, db *gorm.DB) (*MultitenantTypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithID")
@@ -605,8 +618,8 @@ func DefaultDeleteMultitenantTypeWithoutID(ctx context.Context, in *MultitenantT
 	return err
 }
 
-// DefaultListMultitenantTypeWithoutID executes a basic gorm find call
-func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*MultitenantTypeWithoutId, error) {
+// DefaultListMultitenantTypeWithoutID executes a gorm list call
+func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*MultitenantTypeWithoutID, error) {
 	ormResponse := []MultitenantTypeWithoutIDORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
 	if err != nil {
@@ -631,7 +644,7 @@ func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*M
 	return pbResponse, nil
 }
 
-// DefaultUpdateMultitenantTypeWithoutID executes a basic gorm update call
+// DefaultCascadedUpdateMultitenantTypeWithoutID executes a basic gorm update call
 func DefaultCascadedUpdateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithoutID")
@@ -708,7 +721,7 @@ func DefaultDeleteTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db
 	return err
 }
 
-// DefaultListTypeBecomesEmpty executes a basic gorm find call
+// DefaultListTypeBecomesEmpty executes a gorm list call
 func DefaultListTypeBecomesEmpty(ctx context.Context, db *gorm.DB) ([]*TypeBecomesEmpty, error) {
 	ormResponse := []TypeBecomesEmptyORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
@@ -729,7 +742,7 @@ func DefaultListTypeBecomesEmpty(ctx context.Context, db *gorm.DB) ([]*TypeBecom
 	return pbResponse, nil
 }
 
-// DefaultUpdateTypeBecomesEmpty executes a basic gorm update call
+// DefaultCascadedUpdateTypeBecomesEmpty executes a basic gorm update call
 func DefaultCascadedUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeBecomesEmpty")

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -319,7 +319,7 @@ func DefaultListTestTypes(ctx context.Context, db *gorm.DB) ([]*TestTypes, error
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTestTypes executes a basic gorm update call
+// DefaultCascadedUpdateTestTypes clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) (*TestTypes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTestTypes")
@@ -417,7 +417,7 @@ func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithID, err
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTypeWithID executes a basic gorm update call
+// DefaultCascadedUpdateTypeWithID clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeWithID")
@@ -540,7 +540,7 @@ func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*Mult
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateMultitenantTypeWithID executes a basic gorm update call
+// DefaultCascadedUpdateMultitenantTypeWithID clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateMultitenantTypeWithID(ctx context.Context, in *MultitenantTypeWithId, db *gorm.DB) (*MultitenantTypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithID")
@@ -644,7 +644,7 @@ func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*M
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateMultitenantTypeWithoutID executes a basic gorm update call
+// DefaultCascadedUpdateMultitenantTypeWithoutID clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithoutID")
@@ -742,7 +742,7 @@ func DefaultListTypeBecomesEmpty(ctx context.Context, db *gorm.DB) ([]*TypeBecom
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTypeBecomesEmpty executes a basic gorm update call
+// DefaultCascadedUpdateTypeBecomesEmpty clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeBecomesEmpty")

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -3,34 +3,21 @@
 
 package example
 
-import (
-	context "context"
-	errors "errors"
-
-	gorm "github.com/jinzhu/gorm"
-
-	"github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
-	ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
-	uuid "github.com/satori/go.uuid"
-
-	gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
-
-	time "time"
-
-	ptypes "github.com/golang/protobuf/ptypes"
-
-	proto "github.com/gogo/protobuf/proto"
-
-	fmt "fmt"
-
-	math "math"
-
-	_ "github.com/infobloxopen/protoc-gen-gorm/types"
-
-	google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
-
-	_ "github.com/golang/protobuf/ptypes/timestamp"
-)
+import context "context"
+import errors "errors"
+import gorm "github.com/jinzhu/gorm"
+import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
+import uuid "github.com/satori/go.uuid"
+import gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
+import time "time"
+import ptypes "github.com/golang/protobuf/ptypes"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import _ "github.com/infobloxopen/protoc-gen-gorm/types"
+import google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
+import google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
+import _ "github.com/golang/protobuf/ptypes/timestamp"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -319,18 +306,24 @@ func DefaultListTestTypes(ctx context.Context, db *gorm.DB) ([]*TestTypes, error
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTestTypes clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) (*TestTypes, error) {
+// DefaultStrictUpdateTestTypes clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) (*TestTypes, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTestTypes")
 	}
-	ormObj := ConvertTestTypesToORM(*in)
+	ormObj, err := ConvertTestTypesToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertTestTypesFromORM(ormObj)
+	pbResponse, err := ConvertTestTypesFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }
@@ -417,18 +410,24 @@ func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithID, err
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTypeWithID clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
+// DefaultStrictUpdateTypeWithID clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeWithID")
 	}
-	ormObj := ConvertTypeWithIDToORM(*in)
+	ormObj, err := ConvertTypeWithIDToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertTypeWithIDFromORM(ormObj)
+	pbResponse, err := ConvertTypeWithIDFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }
@@ -540,18 +539,24 @@ func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*Mult
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateMultitenantTypeWithID clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateMultitenantTypeWithID(ctx context.Context, in *MultitenantTypeWithId, db *gorm.DB) (*MultitenantTypeWithId, error) {
+// DefaultStrictUpdateMultitenantTypeWithID clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateMultitenantTypeWithID(ctx context.Context, in *MultitenantTypeWithId, db *gorm.DB) (*MultitenantTypeWithId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithID")
 	}
-	ormObj := ConvertMultitenantTypeWithIDToORM(*in)
+	ormObj, err := ConvertMultitenantTypeWithIDToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertMultitenantTypeWithIDFromORM(ormObj)
+	pbResponse, err := ConvertMultitenantTypeWithIDFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }
@@ -644,18 +649,24 @@ func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*M
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateMultitenantTypeWithoutID clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
+// DefaultStrictUpdateMultitenantTypeWithoutID clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithoutID")
 	}
-	ormObj := ConvertMultitenantTypeWithoutIDToORM(*in)
+	ormObj, err := ConvertMultitenantTypeWithoutIDToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertMultitenantTypeWithoutIDFromORM(ormObj)
+	pbResponse, err := ConvertMultitenantTypeWithoutIDFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }
@@ -742,18 +753,24 @@ func DefaultListTypeBecomesEmpty(ctx context.Context, db *gorm.DB) ([]*TypeBecom
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateTypeBecomesEmpty clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
+// DefaultStrictUpdateTypeBecomesEmpty clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeBecomesEmpty")
 	}
-	ormObj := ConvertTypeBecomesEmptyToORM(*in)
+	ormObj, err := ConvertTypeBecomesEmptyToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertTypeBecomesEmptyFromORM(ormObj)
+	pbResponse, err := ConvertTypeBecomesEmptyFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -306,6 +306,22 @@ func DefaultListTestTypes(ctx context.Context, db *gorm.DB) ([]*TestTypes, error
 	return pbResponse, nil
 }
 
+// DefaultUpdateTestTypes executes a basic gorm update call
+func DefaultCascadedUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.DB) (*TestTypes, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTestTypes")
+	}
+	ormObj := ConvertTestTypesToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertTestTypesFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
+}
+
 // DefaultCreateTypeWithID executes a basic gorm create call
 func DefaultCreateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
 	if in == nil {
@@ -386,6 +402,22 @@ func DefaultListTypeWithID(ctx context.Context, db *gorm.DB) ([]*TypeWithId, err
 		pbResponse = append(pbResponse, &temp)
 	}
 	return pbResponse, nil
+}
+
+// DefaultUpdateTypeWithID executes a basic gorm update call
+func DefaultCascadedUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm.DB) (*TypeWithId, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeWithID")
+	}
+	ormObj := ConvertTypeWithIDToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertTypeWithIDFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
 }
 
 // DefaultCreateMultitenantTypeWithID executes a basic gorm create call
@@ -495,6 +527,22 @@ func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*Mult
 	return pbResponse, nil
 }
 
+// DefaultUpdateMultitenantTypeWithID executes a basic gorm update call
+func DefaultCascadedUpdateMultitenantTypeWithID(ctx context.Context, in *MultitenantTypeWithId, db *gorm.DB) (*MultitenantTypeWithId, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithID")
+	}
+	ormObj := ConvertMultitenantTypeWithIDToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertMultitenantTypeWithIDFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
+}
+
 // DefaultCreateMultitenantTypeWithoutID executes a basic gorm create call
 func DefaultCreateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
 	if in == nil {
@@ -583,6 +631,22 @@ func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*M
 	return pbResponse, nil
 }
 
+// DefaultUpdateMultitenantTypeWithoutID executes a basic gorm update call
+func DefaultCascadedUpdateMultitenantTypeWithoutID(ctx context.Context, in *MultitenantTypeWithoutId, db *gorm.DB) (*MultitenantTypeWithoutId, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateMultitenantTypeWithoutID")
+	}
+	ormObj := ConvertMultitenantTypeWithoutIDToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertMultitenantTypeWithoutIDFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
+}
+
 // DefaultCreateTypeBecomesEmpty executes a basic gorm create call
 func DefaultCreateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
 	if in == nil {
@@ -663,4 +727,20 @@ func DefaultListTypeBecomesEmpty(ctx context.Context, db *gorm.DB) ([]*TypeBecom
 		pbResponse = append(pbResponse, &temp)
 	}
 	return pbResponse, nil
+}
+
+// DefaultUpdateTypeBecomesEmpty executes a basic gorm update call
+func DefaultCascadedUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmpty, db *gorm.DB) (*TypeBecomesEmpty, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateTypeBecomesEmpty")
+	}
+	ormObj := ConvertTypeBecomesEmptyToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertTypeBecomesEmptyFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
 }

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -135,18 +135,24 @@ func DefaultListIntPoint(ctx context.Context, db *gorm.DB) ([]*IntPoint, error) 
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateIntPoint clears first level 1:many children and then executes a gorm update call
-func DefaultCascadedUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*IntPoint, error) {
+// DefaultStrictUpdateIntPoint clears first level 1:many children and then executes a gorm update call
+func DefaultStrictUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*IntPoint, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateIntPoint")
 	}
-	ormObj := ConvertIntPointToORM(*in)
+	ormObj, err := ConvertIntPointToORM(*in)
+	if err != nil {
+		return nil, err
+	}
 	tx := db.Begin()
-	if err := tx.Save(&ormObj).Error; err != nil {
+	if err = tx.Save(&ormObj).Error; err != nil {
 		tx.Rollback()
 		return nil, err
 	}
-	pbResponse := ConvertIntPointFromORM(ormObj)
+	pbResponse, err := ConvertIntPointFromORM(ormObj)
+	if err != nil {
+		return nil, err
+	}
 	tx.Commit()
 	return &pbResponse, nil
 }

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -114,7 +114,7 @@ func DefaultDeleteIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) error
 	return err
 }
 
-// DefaultListIntPoint executes a basic gorm find call
+// DefaultListIntPoint executes a gorm list call
 func DefaultListIntPoint(ctx context.Context, db *gorm.DB) ([]*IntPoint, error) {
 	ormResponse := []IntPointORM{}
 	db, err := ops.ApplyCollectionOperators(db, ctx)
@@ -135,7 +135,7 @@ func DefaultListIntPoint(ctx context.Context, db *gorm.DB) ([]*IntPoint, error) 
 	return pbResponse, nil
 }
 
-// DefaultUpdateIntPoint executes a basic gorm update call
+// DefaultCascadedUpdateIntPoint executes a basic gorm update call
 func DefaultCascadedUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*IntPoint, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateIntPoint")

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -134,3 +134,19 @@ func DefaultListIntPoint(ctx context.Context, db *gorm.DB) ([]*IntPoint, error) 
 	}
 	return pbResponse, nil
 }
+
+// DefaultUpdateIntPoint executes a basic gorm update call
+func DefaultCascadedUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*IntPoint, error) {
+	if in == nil {
+		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateIntPoint")
+	}
+	ormObj := ConvertIntPointToORM(*in)
+	tx := db.Begin()
+	if err := tx.Save(&ormObj).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	pbResponse := ConvertIntPointFromORM(ormObj)
+	tx.Commit()
+	return &pbResponse, nil
+}

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -135,7 +135,7 @@ func DefaultListIntPoint(ctx context.Context, db *gorm.DB) ([]*IntPoint, error) 
 	return pbResponse, nil
 }
 
-// DefaultCascadedUpdateIntPoint executes a basic gorm update call
+// DefaultCascadedUpdateIntPoint clears first level 1:many children and then executes a gorm update call
 func DefaultCascadedUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*IntPoint, error) {
 	if in == nil {
 		return nil, fmt.Errorf("Nil argument to DefaultCascadedUpdateIntPoint")

--- a/plugin.go
+++ b/plugin.go
@@ -675,7 +675,6 @@ func (p *ormPlugin) removeNestedAssociations(message *generator.Descriptor) {
 				fieldType, _ := p.GoType(message, field)
 				rawFieldType := strings.Trim(fieldType, "[]*")
 				if _, exists := convertibleTypes[rawFieldType]; exists {
-					//	p.removeNestedAssociations(typeNames[fieldType])
 
 					keys := findAssociationKeys(message, typeNames[typeName], field)
 					childFKeyTypeName := ""
@@ -713,7 +712,7 @@ func (p *ormPlugin) removeNestedAssociations(message *generator.Descriptor) {
 func (p *ormPlugin) generateUpdateWithOverwriteHandler(message *generator.Descriptor) {
 	typeNamePb := generator.CamelCaseSlice(message.TypeName())
 	typeName := lintName(typeNamePb)
-	p.P(`// DefaultUpdate`, typeName, ` executes a basic gorm update call`)
+	p.P(`// DefaultCascadedUpdate`, typeName, ` executes a basic gorm update call`)
 	p.P(`func DefaultCascadedUpdate`, typeName, `(ctx context.Context, in *`,
 		typeNamePb, `, db *`, p.gormPkgAlias, `.DB) (`, `*`, typeNamePb, `, error) {`)
 	p.In()


### PR DESCRIPTION
Add a default handler to remove children objects before updating the parent and rewriting the new children.

Also a couple comment fixes.