### PR TITLE
Fixes for multitenancy

### DIFF
--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -176,15 +176,17 @@ func DefaultStrictUpdateContact(ctx context.Context, in *Contact, db *gorm.DB) (
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	tenantID, tIDErr := auth.GetTenantID(ctx)
+	if tIDErr != nil {
+		return nil, tIDErr
+	}
+	db = db.Where(&ContactORM{TenantID: tenantID})
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertContactFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -315,16 +315,13 @@ func DefaultStrictUpdateTestTypes(ctx context.Context, in *TestTypes, db *gorm.D
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertTestTypesFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }
 
@@ -419,16 +416,13 @@ func DefaultStrictUpdateTypeWithID(ctx context.Context, in *TypeWithId, db *gorm
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertTypeWithIDFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }
 
@@ -524,7 +518,7 @@ func DefaultListMultitenantTypeWithID(ctx context.Context, db *gorm.DB) ([]*Mult
 	if tIDErr != nil {
 		return nil, tIDErr
 	}
-	db = db.Where(&ContactORM{TenantID: tenantID})
+	db = db.Where(&MultitenantTypeWithIDORM{TenantID: tenantID})
 	if err := db.Set("gorm:auto_preload", true).Find(&ormResponse).Error; err != nil {
 		return nil, err
 	}
@@ -548,16 +542,18 @@ func DefaultStrictUpdateMultitenantTypeWithID(ctx context.Context, in *Multitena
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	tenantID, tIDErr := auth.GetTenantID(ctx)
+	if tIDErr != nil {
+		return nil, tIDErr
+	}
+	db = db.Where(&MultitenantTypeWithIDORM{TenantID: tenantID})
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertMultitenantTypeWithIDFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }
 
@@ -634,7 +630,7 @@ func DefaultListMultitenantTypeWithoutID(ctx context.Context, db *gorm.DB) ([]*M
 	if tIDErr != nil {
 		return nil, tIDErr
 	}
-	db = db.Where(&ContactORM{TenantID: tenantID})
+	db = db.Where(&MultitenantTypeWithoutIDORM{TenantID: tenantID})
 	if err := db.Set("gorm:auto_preload", true).Find(&ormResponse).Error; err != nil {
 		return nil, err
 	}
@@ -658,16 +654,18 @@ func DefaultStrictUpdateMultitenantTypeWithoutID(ctx context.Context, in *Multit
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	tenantID, tIDErr := auth.GetTenantID(ctx)
+	if tIDErr != nil {
+		return nil, tIDErr
+	}
+	db = db.Where(&MultitenantTypeWithoutIDORM{TenantID: tenantID})
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertMultitenantTypeWithoutIDFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }
 
@@ -762,15 +760,12 @@ func DefaultStrictUpdateTypeBecomesEmpty(ctx context.Context, in *TypeBecomesEmp
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertTypeBecomesEmptyFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -144,15 +144,12 @@ func DefaultStrictUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB)
 	if err != nil {
 		return nil, err
 	}
-	tx := db.Begin()
-	if err = tx.Save(&ormObj).Error; err != nil {
-		tx.Rollback()
+	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}
 	pbResponse, err := ConvertIntPointFromORM(ormObj)
 	if err != nil {
 		return nil, err
 	}
-	tx.Commit()
 	return &pbResponse, nil
 }


### PR DESCRIPTION
- Check child table for multitenancy
- Fixed some naming errors 
  - was using PB typename instead of ORM typename
  - had a &Contacts somewhere instead of the ORM typename
- Add import to auth if needed
- Remove included transaction in StrictUpdate, now relies on server implementation to handle transaction and rollback on error.

Still has dependency on private repo