### PR TITLE
Makefile: set default GOPATH if not set in env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+GOPATH ?= $(HOME)/go
 SRCPATH := $(patsubst %/,%,$(GOPATH))/src
 
 default: build install


### PR DESCRIPTION
set GOPATH to the [default value](https://golang.org/cmd/go/#hdr-GOPATH_environment_variable) if not provided in the environment