### PR TITLE
Manually delete gogo proto dependencies. Capitalization bugfix.

### DIFF
--- a/example/contacts/contacts.pb.gorm.go
+++ b/example/contacts/contacts.pb.gorm.go
@@ -16,33 +16,21 @@ It has these top-level messages:
 */
 package contacts
 
-import (
-	context "context"
-	errors "errors"
+import context "context"
+import errors "errors"
 
-	gorm "github.com/jinzhu/gorm"
+import auth "github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
+import gorm "github.com/jinzhu/gorm"
+import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
 
-	"github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
-	ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
-	proto "github.com/gogo/protobuf/proto"
-
-	fmt "fmt"
-
-	math "math"
-
-	_ "github.com/golang/protobuf/ptypes/empty"
-
-	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	_ "github.com/lyft/protoc-gen-validate/validate"
-
-	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options"
-
-	_ "github.com/infobloxopen/protoc-gen-gorm/options"
-)
+import fmt "fmt"
+import math "math"
+import _ "github.com/golang/protobuf/ptypes/empty"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options"
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -27,39 +27,25 @@ It has these top-level messages:
 */
 package example
 
-import (
-	context "context"
-	errors "errors"
+import context "context"
+import errors "errors"
+import time "time"
 
-	gorm "github.com/jinzhu/gorm"
+import auth "github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
+import gorm "github.com/jinzhu/gorm"
+import gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
+import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
+import ptypes "github.com/golang/protobuf/ptypes"
+import uuid "github.com/satori/go.uuid"
 
-	"github.com/Infoblox-CTO/ngp.api.toolkit/mw/auth"
-	ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
-	uuid "github.com/satori/go.uuid"
+import fmt "fmt"
+import math "math"
 
-	gtypes "github.com/infobloxopen/protoc-gen-gorm/types"
-
-	time "time"
-
-	ptypes "github.com/golang/protobuf/ptypes"
-
-	proto "github.com/gogo/protobuf/proto"
-
-	fmt "fmt"
-
-	math "math"
-
-	_ "github.com/infobloxopen/protoc-gen-gorm/options"
-
-	_ "github.com/infobloxopen/protoc-gen-gorm/types"
-
-	google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
-
-	_ "github.com/golang/protobuf/ptypes/timestamp"
-)
+import google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
+import google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
+import _ "github.com/golang/protobuf/ptypes/timestamp"
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 

--- a/example/feature_demo/test.pb.gorm.go
+++ b/example/feature_demo/test.pb.gorm.go
@@ -40,7 +40,6 @@ import uuid "github.com/satori/go.uuid"
 
 import fmt "fmt"
 import math "math"
-
 import google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
 import google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
 import _ "github.com/golang/protobuf/ptypes/timestamp"

--- a/example/feature_demo/test2.pb.gorm.go
+++ b/example/feature_demo/test2.pb.gorm.go
@@ -5,18 +5,16 @@ package example
 
 import context "context"
 import errors "errors"
-import gorm "github.com/jinzhu/gorm"
-import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
-import grpc "google.golang.org/grpc"
 
-import proto "github.com/gogo/protobuf/proto"
+import gorm "github.com/jinzhu/gorm"
+import grpc "google.golang.org/grpc"
+import ops "github.com/Infoblox-CTO/ngp.api.toolkit/op/gorm"
+
 import fmt "fmt"
 import math "math"
 import google_protobuf2 "github.com/golang/protobuf/ptypes/empty"
-import _ "github.com/infobloxopen/protoc-gen-gorm/options"
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,35 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/gogo/protobuf/vanity/command"
 )
 
 func main() {
-	command.Write(command.GeneratePlugin(command.Read(), &ormPlugin{}, ".pb.gorm.go"))
+	response := command.GeneratePlugin(command.Read(), &ormPlugin{}, ".pb.gorm.go")
+	for _, file := range response.GetFile() {
+		file.Content = cleanImports(file.Content)
+	}
+	command.Write(response)
+}
+
+// Imports that are added by default but unneeded in GORM code
+var unneededImports = []string{
+	"import proto \"github.com/gogo/protobuf/proto\"\n",
+	"import _ \"github.com/infobloxopen/protoc-gen-gorm/options\"\n",
+	// if needed will be imported with an alias
+	"import _ \"github.com/infobloxopen/protoc-gen-gorm/types\"",
+	"var _ = proto.Marshal\n",
+}
+
+func cleanImports(pFileText *string) *string {
+	if pFileText == nil {
+		return pFileText
+	}
+	fileText := *pFileText
+	for _, dep := range unneededImports {
+		fileText = strings.Replace(fileText, dep, "", -1)
+	}
+	return &fileText
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var unneededImports = []string{
 	"import proto \"github.com/gogo/protobuf/proto\"\n",
 	"import _ \"github.com/infobloxopen/protoc-gen-gorm/options\"\n",
 	// if needed will be imported with an alias
-	"import _ \"github.com/infobloxopen/protoc-gen-gorm/types\"",
+	"import _ \"github.com/infobloxopen/protoc-gen-gorm/types\"\n",
 	"var _ = proto.Marshal\n",
 }
 


### PR DESCRIPTION
Manually remove some lines from generated files that gogo auto inserts to remove dependency on gogo

Lint name stripped of * and []* so that it matches properly (addresses issue #19 )

Order imports better

Actually set multi tenant flag so that import happens