### PR TITLE
Fix account_id override on update, PUT as update only, no upsert

### DIFF
--- a/example/feature_demo/demo_service.pb.gorm.go
+++ b/example/feature_demo/demo_service.pb.gorm.go
@@ -127,6 +127,11 @@ func DefaultUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB) (*Int
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateIntPoint")
 	}
+	if exists, err := DefaultReadIntPoint(ctx, &IntPoint{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("IntPoint not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -161,6 +166,11 @@ func DefaultStrictUpdateIntPoint(ctx context.Context, in *IntPoint, db *gorm.DB)
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadIntPoint(ctx, &IntPoint{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("IntPoint not found")
 	}
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err

--- a/example/feature_demo/demo_types.pb.gorm.go
+++ b/example/feature_demo/demo_types.pb.gorm.go
@@ -478,6 +478,11 @@ func DefaultUpdateTypeWithID(ctx context.Context, in *TypeWithID, db *gorm.DB) (
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateTypeWithID")
 	}
+	if exists, err := DefaultReadTypeWithID(ctx, &TypeWithID{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("TypeWithID not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -512,6 +517,11 @@ func DefaultStrictUpdateTypeWithID(ctx context.Context, in *TypeWithID, db *gorm
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadTypeWithID(ctx, &TypeWithID{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("TypeWithID not found")
 	}
 	filterANestedObject := TestTypesORM{}
 	if ormObj.Id == 0 {
@@ -608,12 +618,17 @@ func DefaultUpdateMultiaccountTypeWithID(ctx context.Context, in *MultiaccountTy
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateMultiaccountTypeWithID")
 	}
+	accountID, err := auth.GetAccountID(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
 	if exists, err := DefaultReadMultiaccountTypeWithID(ctx, &MultiaccountTypeWithID{Id: in.GetId()}, db); err != nil {
 		return nil, err
 	} else if exists == nil {
 		return nil, errors.New("MultiaccountTypeWithID not found")
 	}
 	ormObj, err := in.ToORM(ctx)
+	ormObj.AccountID = accountID
 	if err != nil {
 		return nil, err
 	}
@@ -657,6 +672,12 @@ func DefaultStrictUpdateMultiaccountTypeWithID(ctx context.Context, in *Multiacc
 	if err != nil {
 		return nil, err
 	}
+	if exists, err := DefaultReadMultiaccountTypeWithID(ctx, &MultiaccountTypeWithID{Id: in.Id}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("MultiaccountTypeWithID not found")
+	}
+	ormObj.AccountID = accountID
 	db = db.Where(&MultiaccountTypeWithIDORM{AccountID: accountID})
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err

--- a/example/user/user.pb.gorm.go
+++ b/example/user/user.pb.gorm.go
@@ -691,6 +691,11 @@ func DefaultUpdateUser(ctx context.Context, in *User, db *gorm.DB) (*User, error
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateUser")
 	}
+	if exists, err := DefaultReadUser(ctx, &User{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("User not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -728,6 +733,11 @@ func DefaultStrictUpdateUser(ctx context.Context, in *User, db *gorm.DB) (*User,
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadUser(ctx, &User{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("User not found")
 	}
 	filterCreditCard := CreditCardORM{}
 	if ormObj.Id == 0 {
@@ -828,6 +838,11 @@ func DefaultUpdateEmail(ctx context.Context, in *Email, db *gorm.DB) (*Email, er
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateEmail")
 	}
+	if exists, err := DefaultReadEmail(ctx, &Email{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Email not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -862,6 +877,11 @@ func DefaultStrictUpdateEmail(ctx context.Context, in *Email, db *gorm.DB) (*Ema
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadEmail(ctx, &Email{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Email not found")
 	}
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
@@ -932,6 +952,11 @@ func DefaultUpdateAddress(ctx context.Context, in *Address, db *gorm.DB) (*Addre
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateAddress")
 	}
+	if exists, err := DefaultReadAddress(ctx, &Address{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Address not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -966,6 +991,11 @@ func DefaultStrictUpdateAddress(ctx context.Context, in *Address, db *gorm.DB) (
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadAddress(ctx, &Address{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Address not found")
 	}
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
@@ -1036,6 +1066,11 @@ func DefaultUpdateLanguage(ctx context.Context, in *Language, db *gorm.DB) (*Lan
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateLanguage")
 	}
+	if exists, err := DefaultReadLanguage(ctx, &Language{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Language not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -1070,6 +1105,11 @@ func DefaultStrictUpdateLanguage(ctx context.Context, in *Language, db *gorm.DB)
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadLanguage(ctx, &Language{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("Language not found")
 	}
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
@@ -1140,6 +1180,11 @@ func DefaultUpdateCreditCard(ctx context.Context, in *CreditCard, db *gorm.DB) (
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateCreditCard")
 	}
+	if exists, err := DefaultReadCreditCard(ctx, &CreditCard{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("CreditCard not found")
+	}
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
@@ -1174,6 +1219,11 @@ func DefaultStrictUpdateCreditCard(ctx context.Context, in *CreditCard, db *gorm
 	ormObj, err := in.ToORM(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if exists, err := DefaultReadCreditCard(ctx, &CreditCard{Id: in.GetId()}, db); err != nil {
+		return nil, err
+	} else if exists == nil {
+		return nil, errors.New("CreditCard not found")
 	}
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err


### PR DESCRIPTION
Was not repopulating AccountID before Update, causing it to be overwritten with emptiness. 

Now attempts a Read before Update to check if object exists. This should prevent UPSERT behavior, and force only Update.