### PR TITLE
Fix multi-account AccountID field being wiped on update calls

### DIFF
--- a/example/feature_demo/demo_types.pb.gorm.go
+++ b/example/feature_demo/demo_types.pb.gorm.go
@@ -618,11 +618,11 @@ func DefaultUpdateMultiaccountTypeWithID(ctx context.Context, in *MultiaccountTy
 		return nil, errors.New("MultiaccountTypeWithID not found")
 	}
 	ormObj, err := in.ToORM(ctx)
-	ormObj.AccountID = accountID
-	db = db.Where(&MultiaccountTypeWithIDORM{AccountID: accountID})
 	if err != nil {
 		return nil, err
 	}
+	ormObj.AccountID = accountID
+	db = db.Where(&MultiaccountTypeWithIDORM{AccountID: accountID})
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err
 	}

--- a/example/feature_demo/demo_types.pb.gorm.go
+++ b/example/feature_demo/demo_types.pb.gorm.go
@@ -608,12 +608,18 @@ func DefaultUpdateMultiaccountTypeWithID(ctx context.Context, in *MultiaccountTy
 	if in == nil {
 		return nil, errors.New("Nil argument to DefaultUpdateMultiaccountTypeWithID")
 	}
+	accountID, err := auth.GetAccountID(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
 	if exists, err := DefaultReadMultiaccountTypeWithID(ctx, &MultiaccountTypeWithID{Id: in.GetId()}, db); err != nil {
 		return nil, err
 	} else if exists == nil {
 		return nil, errors.New("MultiaccountTypeWithID not found")
 	}
 	ormObj, err := in.ToORM(ctx)
+	ormObj.AccountID = accountID
+	db = db.Where(&MultiaccountTypeWithIDORM{AccountID: accountID})
 	if err != nil {
 		return nil, err
 	}
@@ -657,6 +663,7 @@ func DefaultStrictUpdateMultiaccountTypeWithID(ctx context.Context, in *Multiacc
 	if err != nil {
 		return nil, err
 	}
+	ormObj.AccountID = accountID
 	db = db.Where(&MultiaccountTypeWithIDORM{AccountID: accountID})
 	if err = db.Save(&ormObj).Error; err != nil {
 		return nil, err

--- a/plugin/handlergen.go
+++ b/plugin/handlergen.go
@@ -119,6 +119,10 @@ func (p *OrmPlugin) generateUpdateHandler(message *generator.Descriptor) {
 	p.P(`return nil, errors.New("Nil argument to DefaultUpdate`, typeName, `")`)
 	p.P(`}`)
 	if isMultiAccount {
+		p.P("accountID, err := auth.GetAccountID(ctx, nil)")
+		p.P("if err != nil {")
+		p.P("return nil, err")
+		p.P("}")
 		p.P(fmt.Sprintf("if exists, err := DefaultRead%s(ctx, &%s{Id: in.GetId()}, db); err != nil {",
 			typeName, typeName))
 		p.P("return nil, err")
@@ -128,6 +132,10 @@ func (p *OrmPlugin) generateUpdateHandler(message *generator.Descriptor) {
 	}
 
 	p.P(`ormObj, err := in.ToORM(ctx)`)
+	if isMultiAccount {
+		p.P(`ormObj.AccountID = accountID`)
+		p.P(`db = db.Where(&`, typeName, `ORM{AccountID: accountID})`)
+	}
 	p.P(`if err != nil {`)
 	p.P(`return nil, err`)
 	p.P(`}`)
@@ -226,6 +234,7 @@ func (p *OrmPlugin) generateStrictUpdateHandler(message *generator.Descriptor) {
 	}
 	p.removeChildAssociations(message)
 	if multiAccount {
+		p.P(`ormObj.AccountID = accountID`)
 		p.P(`db = db.Where(&`, typeName, `ORM{AccountID: accountID})`)
 	}
 	p.setupOrderedHasMany(message)

--- a/plugin/handlergen.go
+++ b/plugin/handlergen.go
@@ -132,13 +132,13 @@ func (p *OrmPlugin) generateUpdateHandler(message *generator.Descriptor) {
 	}
 
 	p.P(`ormObj, err := in.ToORM(ctx)`)
+	p.P(`if err != nil {`)
+	p.P(`return nil, err`)
+	p.P(`}`)
 	if isMultiAccount {
 		p.P(`ormObj.AccountID = accountID`)
 		p.P(`db = db.Where(&`, typeName, `ORM{AccountID: accountID})`)
 	}
-	p.P(`if err != nil {`)
-	p.P(`return nil, err`)
-	p.P(`}`)
 	p.setupOrderedHasMany(message)
 	p.P(`if err = db.Save(&ormObj).Error; err != nil {`)
 	p.P(`return nil, err`)


### PR DESCRIPTION
Fix mostly unused default update and standard hard-update with child replacement