### PR TITLE
Don't generate invalid code if child is not multi-account but parent is

### DIFF
--- a/plugin/handlergen.go
+++ b/plugin/handlergen.go
@@ -292,11 +292,11 @@ func (p *OrmPlugin) removeChildAssociations(message *generator.Descriptor) {
 			}
 			p.P(`filter`, fieldName, ` := `, strings.Trim(field.Type, "[]*"), `{}`)
 			zeroValue := p.guessZeroValue(ormable.Fields[assocKeyName].Type)
-			p.P(`if ormObj.`, assocKeyName, ` == `, zeroValue, `{`)
+			p.P(`if ormObj.`, assocKeyName, ` == `, zeroValue, ` {`)
 			p.P(`return nil, errors.New("Can't do overwriting update with no `, assocKeyName, ` value for `, ormable.Name, `")`)
 			p.P(`}`)
 			p.P(`filter`, fieldName, `.`, foreignKeyName, ` = `, `ormObj.`, assocKeyName)
-			if getMessageOptions(message).GetMultiAccount() {
+			if _, ok := p.getOrmable(strings.TrimSuffix(field.Type, "ORM")).Fields["AccountID"]; ok {
 				p.P(`filter`, fieldName, `.`, `AccountID`, ` = accountID`)
 			}
 			p.P(`if err = db.Where(filter`, fieldName, `).Delete(`, strings.Trim(field.Type, "[]*"), `{}).Error; err != nil {`)


### PR DESCRIPTION
Code generated for removing child objects was based on whether parent was a multi-account type. It may be good to enforce children of multi-account objects also being multi-account, but since that isn't enforced currently, this will prevent invalid code from being generated.