### PR TITLE
Fixes for returns of txn-middleware autogenerated code

### DIFF
--- a/example/feature_demo/demo_service.pb.gorm.go
+++ b/example/feature_demo/demo_service.pb.gorm.go
@@ -321,9 +321,12 @@ func (m *IntPointTxnDefaultServer) Create(ctx context.Context, in *CreateIntPoin
 	}
 	txn, ok := tkgorm.FromContext(ctx)
 	if !ok {
-		return &CreateIntPointResponse{}, errors.New("Database Transaction For Request Missing")
+		return nil, errors.New("Database Transaction For Request Missing")
 	}
 	db := txn.Begin()
+	if db.Error != nil {
+		return nil, db.Error
+	}
 	res, err := DefaultCreateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
 		return nil, err
@@ -342,9 +345,12 @@ func (m *IntPointTxnDefaultServer) Read(ctx context.Context, in *ReadIntPointReq
 	}
 	txn, ok := tkgorm.FromContext(ctx)
 	if !ok {
-		return &ReadIntPointResponse{}, errors.New("Database Transaction For Request Missing")
+		return nil, errors.New("Database Transaction For Request Missing")
 	}
 	db := txn.Begin()
+	if db.Error != nil {
+		return nil, db.Error
+	}
 	res, err := DefaultReadIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 	if err != nil {
 		return nil, err
@@ -363,9 +369,12 @@ func (m *IntPointTxnDefaultServer) Update(ctx context.Context, in *UpdateIntPoin
 	}
 	txn, ok := tkgorm.FromContext(ctx)
 	if !ok {
-		return &UpdateIntPointResponse{}, errors.New("Database Transaction For Request Missing")
+		return nil, errors.New("Database Transaction For Request Missing")
 	}
 	db := txn.Begin()
+	if db.Error != nil {
+		return nil, db.Error
+	}
 	res, err := DefaultStrictUpdateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
 		return nil, err
@@ -384,9 +393,12 @@ func (m *IntPointTxnDefaultServer) List(ctx context.Context, in *google_protobuf
 	}
 	txn, ok := tkgorm.FromContext(ctx)
 	if !ok {
-		return &ListIntPointResponse{}, errors.New("Database Transaction For Request Missing")
+		return nil, errors.New("Database Transaction For Request Missing")
 	}
 	db := txn.Begin()
+	if db.Error != nil {
+		return nil, db.Error
+	}
 	res, err := DefaultListIntPoint(ctx, db)
 	if err != nil {
 		return nil, err
@@ -405,9 +417,12 @@ func (m *IntPointTxnDefaultServer) Delete(ctx context.Context, in *DeleteIntPoin
 	}
 	txn, ok := tkgorm.FromContext(ctx)
 	if !ok {
-		return &DeleteIntPointResponse{}, errors.New("Database Transaction For Request Missing")
+		return nil, errors.New("Database Transaction For Request Missing")
 	}
 	db := txn.Begin()
+	if db.Error != nil {
+		return nil, db.Error
+	}
 	return &DeleteIntPointResponse{}, DefaultDeleteIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 }
 

--- a/plugin/servergen.go
+++ b/plugin/servergen.go
@@ -274,9 +274,12 @@ func (p *OrmPlugin) generateDBSetup(service *descriptor.ServiceDescriptorProto, 
 	if opts := getServiceOptions(service); opts != nil && opts.GetTxnMiddleware() {
 		p.P(`txn, ok := tkgorm.FromContext(ctx)`)
 		p.P(`if !ok {`)
-		p.P(`return &`, p.TypeName(outType), `{}, errors.New("Database Transaction For Request Missing")`)
+		p.P(`return nil, errors.New("Database Transaction For Request Missing")`)
 		p.P(`}`)
 		p.P(`db := txn.Begin()`)
+		p.P(`if db.Error != nil {`)
+		p.P(`return nil, db.Error`)
+		p.P(`}`)
 	} else {
 		p.P(`db := m.DB`)
 	}


### PR DESCRIPTION
Addresses concerns over transaction middleware related generated code:
- Returning empty instead of nil on error
- Not checking for an error starting transaction before attempting to use transaction

Does not address requested change to app-toolkit to streamline the process of
1. Get transaction from context
2. Begin transaction
3. Check for errors

If this change in toolkit is made, cannot be safely applied to generated code until after next release anyway.