### PR TITLE
Prehook to replace fairly useless method override hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ For CRUD methods to be generated correctly you need to follow specific conventio
 - Delete methods require the `(gorm.method).object_type` option to indicate
   which Ormable Type it should delete, and has no response type requirements.
 
+To customize the generated server, embed it into a new type and override any
+desired functions.
+
 If conventions are not met stubs are generated for CRUD methods. As seen in the
 [feature_demo/demo_service](example/feature_demo/demo_service.proto) example.
 

--- a/example/feature_demo/demo_service.pb.gorm.go
+++ b/example/feature_demo/demo_service.pb.gorm.go
@@ -283,7 +283,7 @@ func (m *IntPointServiceDefaultServer) Read(ctx context.Context, in *ReadIntPoin
 	return &ReadIntPointResponse{Result: res}, nil
 }
 
-// IntPointServiceIntPointWithBeforeRead called before DefaultCreateIntPoint in the default Create handler
+// IntPointServiceIntPointWithBeforeRead called before DefaultReadIntPoint in the default Read handler
 type IntPointServiceIntPointWithBeforeRead interface {
 	BeforeRead(context.Context, *ReadIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -305,7 +305,7 @@ func (m *IntPointServiceDefaultServer) Update(ctx context.Context, in *UpdateInt
 	return &UpdateIntPointResponse{Result: res}, nil
 }
 
-// IntPointServiceIntPointWithBeforeUpdate called before DefaultCreateIntPoint in the default Create handler
+// IntPointServiceIntPointWithBeforeUpdate called before DefaultUpdateIntPoint in the default Update handler
 type IntPointServiceIntPointWithBeforeUpdate interface {
 	BeforeUpdate(context.Context, *UpdateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -327,7 +327,7 @@ func (m *IntPointServiceDefaultServer) List(ctx context.Context, in *ListIntPoin
 	return &ListIntPointResponse{Results: res}, nil
 }
 
-// IntPointServiceIntPointWithBeforeList called before DefaultCreateIntPoint in the default Create handler
+// IntPointServiceIntPointWithBeforeList called before DefaultListIntPoint in the default List handler
 type IntPointServiceIntPointWithBeforeList interface {
 	BeforeList(context.Context, *ListIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -345,7 +345,7 @@ func (m *IntPointServiceDefaultServer) Delete(ctx context.Context, in *DeleteInt
 	return &DeleteIntPointResponse{}, DefaultDeleteIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 }
 
-// IntPointServiceIntPointWithBeforeDelete called before DefaultCreateIntPoint in the default Create handler
+// IntPointServiceIntPointWithBeforeDelete called before DefaultDeleteIntPoint in the default Delete handler
 type IntPointServiceIntPointWithBeforeDelete interface {
 	BeforeDelete(context.Context, *DeleteIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -416,7 +416,7 @@ func (m *IntPointTxnDefaultServer) Read(ctx context.Context, in *ReadIntPointReq
 	return &ReadIntPointResponse{Result: res}, nil
 }
 
-// IntPointTxnIntPointWithBeforeRead called before DefaultCreateIntPoint in the default Create handler
+// IntPointTxnIntPointWithBeforeRead called before DefaultReadIntPoint in the default Read handler
 type IntPointTxnIntPointWithBeforeRead interface {
 	BeforeRead(context.Context, *ReadIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -445,7 +445,7 @@ func (m *IntPointTxnDefaultServer) Update(ctx context.Context, in *UpdateIntPoin
 	return &UpdateIntPointResponse{Result: res}, nil
 }
 
-// IntPointTxnIntPointWithBeforeUpdate called before DefaultCreateIntPoint in the default Create handler
+// IntPointTxnIntPointWithBeforeUpdate called before DefaultUpdateIntPoint in the default Update handler
 type IntPointTxnIntPointWithBeforeUpdate interface {
 	BeforeUpdate(context.Context, *UpdateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -474,7 +474,7 @@ func (m *IntPointTxnDefaultServer) List(ctx context.Context, in *google_protobuf
 	return &ListIntPointResponse{Results: res}, nil
 }
 
-// IntPointTxnIntPointWithBeforeList called before DefaultCreateIntPoint in the default Create handler
+// IntPointTxnIntPointWithBeforeList called before DefaultListIntPoint in the default List handler
 type IntPointTxnIntPointWithBeforeList interface {
 	BeforeList(context.Context, *google_protobuf2.Empty, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
@@ -499,7 +499,7 @@ func (m *IntPointTxnDefaultServer) Delete(ctx context.Context, in *DeleteIntPoin
 	return &DeleteIntPointResponse{}, DefaultDeleteIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 }
 
-// IntPointTxnIntPointWithBeforeDelete called before DefaultCreateIntPoint in the default Create handler
+// IntPointTxnIntPointWithBeforeDelete called before DefaultDeleteIntPoint in the default Delete handler
 type IntPointTxnIntPointWithBeforeDelete interface {
 	BeforeDelete(context.Context, *DeleteIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }

--- a/example/feature_demo/demo_service.pb.gorm.go
+++ b/example/feature_demo/demo_service.pb.gorm.go
@@ -243,16 +243,17 @@ func DefaultListIntPoint(ctx context.Context, db *gorm1.DB, req interface{}) ([]
 type IntPointServiceDefaultServer struct {
 	DB *gorm1.DB
 }
-type IntPointServiceCreateCustomHandler interface {
-	CustomCreate(context.Context, *CreateIntPointRequest) (*CreateIntPointResponse, error)
-}
 
 // Create ...
 func (m *IntPointServiceDefaultServer) Create(ctx context.Context, in *CreateIntPointRequest) (*CreateIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointServiceCreateCustomHandler); ok {
-		return custom.CustomCreate(ctx, in)
-	}
 	db := m.DB
+	if custom, ok := interface{}(in).(IntPointServiceIntPointWithBeforeCreate); ok {
+		var err error
+		ctx, db, err = custom.BeforeCreate(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	res, err := DefaultCreateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
 		return nil, err
@@ -260,16 +261,21 @@ func (m *IntPointServiceDefaultServer) Create(ctx context.Context, in *CreateInt
 	return &CreateIntPointResponse{Result: res}, nil
 }
 
-type IntPointServiceReadCustomHandler interface {
-	CustomRead(context.Context, *ReadIntPointRequest) (*ReadIntPointResponse, error)
+// IntPointServiceIntPointWithBeforeCreate called before DefaultCreateIntPoint in the default Create handler
+type IntPointServiceIntPointWithBeforeCreate interface {
+	BeforeCreate(context.Context, *CreateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Read ...
 func (m *IntPointServiceDefaultServer) Read(ctx context.Context, in *ReadIntPointRequest) (*ReadIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointServiceReadCustomHandler); ok {
-		return custom.CustomRead(ctx, in)
-	}
 	db := m.DB
+	if custom, ok := interface{}(in).(IntPointServiceIntPointWithBeforeRead); ok {
+		var err error
+		ctx, db, err = custom.BeforeRead(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	res, err := DefaultReadIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 	if err != nil {
 		return nil, err
@@ -277,16 +283,21 @@ func (m *IntPointServiceDefaultServer) Read(ctx context.Context, in *ReadIntPoin
 	return &ReadIntPointResponse{Result: res}, nil
 }
 
-type IntPointServiceUpdateCustomHandler interface {
-	CustomUpdate(context.Context, *UpdateIntPointRequest) (*UpdateIntPointResponse, error)
+// IntPointServiceIntPointWithBeforeRead called before DefaultCreateIntPoint in the default Create handler
+type IntPointServiceIntPointWithBeforeRead interface {
+	BeforeRead(context.Context, *ReadIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Update ...
 func (m *IntPointServiceDefaultServer) Update(ctx context.Context, in *UpdateIntPointRequest) (*UpdateIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointServiceUpdateCustomHandler); ok {
-		return custom.CustomUpdate(ctx, in)
-	}
 	db := m.DB
+	if custom, ok := interface{}(in).(IntPointServiceIntPointWithBeforeUpdate); ok {
+		var err error
+		ctx, db, err = custom.BeforeUpdate(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	res, err := DefaultStrictUpdateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
 		return nil, err
@@ -294,16 +305,21 @@ func (m *IntPointServiceDefaultServer) Update(ctx context.Context, in *UpdateInt
 	return &UpdateIntPointResponse{Result: res}, nil
 }
 
-type IntPointServiceListCustomHandler interface {
-	CustomList(context.Context, *ListIntPointRequest) (*ListIntPointResponse, error)
+// IntPointServiceIntPointWithBeforeUpdate called before DefaultCreateIntPoint in the default Create handler
+type IntPointServiceIntPointWithBeforeUpdate interface {
+	BeforeUpdate(context.Context, *UpdateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // List ...
 func (m *IntPointServiceDefaultServer) List(ctx context.Context, in *ListIntPointRequest) (*ListIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointServiceListCustomHandler); ok {
-		return custom.CustomList(ctx, in)
-	}
 	db := m.DB
+	if custom, ok := interface{}(in).(IntPointServiceIntPointWithBeforeList); ok {
+		var err error
+		ctx, db, err = custom.BeforeList(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	res, err := DefaultListIntPoint(ctx, db, in)
 	if err != nil {
 		return nil, err
@@ -311,54 +327,44 @@ func (m *IntPointServiceDefaultServer) List(ctx context.Context, in *ListIntPoin
 	return &ListIntPointResponse{Results: res}, nil
 }
 
-type IntPointServiceDeleteCustomHandler interface {
-	CustomDelete(context.Context, *DeleteIntPointRequest) (*DeleteIntPointResponse, error)
+// IntPointServiceIntPointWithBeforeList called before DefaultCreateIntPoint in the default Create handler
+type IntPointServiceIntPointWithBeforeList interface {
+	BeforeList(context.Context, *ListIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Delete ...
 func (m *IntPointServiceDefaultServer) Delete(ctx context.Context, in *DeleteIntPointRequest) (*DeleteIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointServiceDeleteCustomHandler); ok {
-		return custom.CustomDelete(ctx, in)
-	}
 	db := m.DB
+	if custom, ok := interface{}(in).(IntPointServiceIntPointWithBeforeDelete); ok {
+		var err error
+		ctx, db, err = custom.BeforeDelete(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &DeleteIntPointResponse{}, DefaultDeleteIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 }
 
-type IntPointServiceCustomMethodCustomHandler interface {
-	CustomCustomMethod(context.Context, *google_protobuf2.Empty) (*google_protobuf2.Empty, error)
+// IntPointServiceIntPointWithBeforeDelete called before DefaultCreateIntPoint in the default Create handler
+type IntPointServiceIntPointWithBeforeDelete interface {
+	BeforeDelete(context.Context, *DeleteIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // CustomMethod ...
 func (m *IntPointServiceDefaultServer) CustomMethod(ctx context.Context, in *google_protobuf2.Empty) (*google_protobuf2.Empty, error) {
-	if custom, ok := interface{}(m).(IntPointServiceCustomMethodCustomHandler); ok {
-		return custom.CustomCustomMethod(ctx, in)
-	}
 	return &google_protobuf2.Empty{}, nil
-}
-
-type IntPointServiceCreateSomethingCustomHandler interface {
-	CustomCreateSomething(context.Context, *Something) (*Something, error)
 }
 
 // CreateSomething ...
 func (m *IntPointServiceDefaultServer) CreateSomething(ctx context.Context, in *Something) (*Something, error) {
-	if custom, ok := interface{}(m).(IntPointServiceCreateSomethingCustomHandler); ok {
-		return custom.CustomCreateSomething(ctx, in)
-	}
 	return &Something{}, nil
 }
 
 type IntPointTxnDefaultServer struct {
 }
-type IntPointTxnCreateCustomHandler interface {
-	CustomCreate(context.Context, *CreateIntPointRequest) (*CreateIntPointResponse, error)
-}
 
 // Create ...
 func (m *IntPointTxnDefaultServer) Create(ctx context.Context, in *CreateIntPointRequest) (*CreateIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointTxnCreateCustomHandler); ok {
-		return custom.CustomCreate(ctx, in)
-	}
 	txn, ok := gorm2.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Database Transaction For Request Missing")
@@ -366,6 +372,13 @@ func (m *IntPointTxnDefaultServer) Create(ctx context.Context, in *CreateIntPoin
 	db := txn.Begin()
 	if db.Error != nil {
 		return nil, db.Error
+	}
+	if custom, ok := interface{}(in).(IntPointTxnIntPointWithBeforeCreate); ok {
+		var err error
+		ctx, db, err = custom.BeforeCreate(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
 	}
 	res, err := DefaultCreateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
@@ -374,15 +387,13 @@ func (m *IntPointTxnDefaultServer) Create(ctx context.Context, in *CreateIntPoin
 	return &CreateIntPointResponse{Result: res}, nil
 }
 
-type IntPointTxnReadCustomHandler interface {
-	CustomRead(context.Context, *ReadIntPointRequest) (*ReadIntPointResponse, error)
+// IntPointTxnIntPointWithBeforeCreate called before DefaultCreateIntPoint in the default Create handler
+type IntPointTxnIntPointWithBeforeCreate interface {
+	BeforeCreate(context.Context, *CreateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Read ...
 func (m *IntPointTxnDefaultServer) Read(ctx context.Context, in *ReadIntPointRequest) (*ReadIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointTxnReadCustomHandler); ok {
-		return custom.CustomRead(ctx, in)
-	}
 	txn, ok := gorm2.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Database Transaction For Request Missing")
@@ -390,6 +401,13 @@ func (m *IntPointTxnDefaultServer) Read(ctx context.Context, in *ReadIntPointReq
 	db := txn.Begin()
 	if db.Error != nil {
 		return nil, db.Error
+	}
+	if custom, ok := interface{}(in).(IntPointTxnIntPointWithBeforeRead); ok {
+		var err error
+		ctx, db, err = custom.BeforeRead(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
 	}
 	res, err := DefaultReadIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 	if err != nil {
@@ -398,15 +416,13 @@ func (m *IntPointTxnDefaultServer) Read(ctx context.Context, in *ReadIntPointReq
 	return &ReadIntPointResponse{Result: res}, nil
 }
 
-type IntPointTxnUpdateCustomHandler interface {
-	CustomUpdate(context.Context, *UpdateIntPointRequest) (*UpdateIntPointResponse, error)
+// IntPointTxnIntPointWithBeforeRead called before DefaultCreateIntPoint in the default Create handler
+type IntPointTxnIntPointWithBeforeRead interface {
+	BeforeRead(context.Context, *ReadIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Update ...
 func (m *IntPointTxnDefaultServer) Update(ctx context.Context, in *UpdateIntPointRequest) (*UpdateIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointTxnUpdateCustomHandler); ok {
-		return custom.CustomUpdate(ctx, in)
-	}
 	txn, ok := gorm2.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Database Transaction For Request Missing")
@@ -414,6 +430,13 @@ func (m *IntPointTxnDefaultServer) Update(ctx context.Context, in *UpdateIntPoin
 	db := txn.Begin()
 	if db.Error != nil {
 		return nil, db.Error
+	}
+	if custom, ok := interface{}(in).(IntPointTxnIntPointWithBeforeUpdate); ok {
+		var err error
+		ctx, db, err = custom.BeforeUpdate(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
 	}
 	res, err := DefaultStrictUpdateIntPoint(ctx, in.GetPayload(), db)
 	if err != nil {
@@ -422,15 +445,13 @@ func (m *IntPointTxnDefaultServer) Update(ctx context.Context, in *UpdateIntPoin
 	return &UpdateIntPointResponse{Result: res}, nil
 }
 
-type IntPointTxnListCustomHandler interface {
-	CustomList(context.Context, *google_protobuf2.Empty) (*ListIntPointResponse, error)
+// IntPointTxnIntPointWithBeforeUpdate called before DefaultCreateIntPoint in the default Create handler
+type IntPointTxnIntPointWithBeforeUpdate interface {
+	BeforeUpdate(context.Context, *UpdateIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // List ...
 func (m *IntPointTxnDefaultServer) List(ctx context.Context, in *google_protobuf2.Empty) (*ListIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointTxnListCustomHandler); ok {
-		return custom.CustomList(ctx, in)
-	}
 	txn, ok := gorm2.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Database Transaction For Request Missing")
@@ -438,6 +459,13 @@ func (m *IntPointTxnDefaultServer) List(ctx context.Context, in *google_protobuf
 	db := txn.Begin()
 	if db.Error != nil {
 		return nil, db.Error
+	}
+	if custom, ok := interface{}(in).(IntPointTxnIntPointWithBeforeList); ok {
+		var err error
+		ctx, db, err = custom.BeforeList(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
 	}
 	res, err := DefaultListIntPoint(ctx, db, in)
 	if err != nil {
@@ -446,15 +474,13 @@ func (m *IntPointTxnDefaultServer) List(ctx context.Context, in *google_protobuf
 	return &ListIntPointResponse{Results: res}, nil
 }
 
-type IntPointTxnDeleteCustomHandler interface {
-	CustomDelete(context.Context, *DeleteIntPointRequest) (*DeleteIntPointResponse, error)
+// IntPointTxnIntPointWithBeforeList called before DefaultCreateIntPoint in the default Create handler
+type IntPointTxnIntPointWithBeforeList interface {
+	BeforeList(context.Context, *google_protobuf2.Empty, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // Delete ...
 func (m *IntPointTxnDefaultServer) Delete(ctx context.Context, in *DeleteIntPointRequest) (*DeleteIntPointResponse, error) {
-	if custom, ok := interface{}(m).(IntPointTxnDeleteCustomHandler); ok {
-		return custom.CustomDelete(ctx, in)
-	}
 	txn, ok := gorm2.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("Database Transaction For Request Missing")
@@ -463,29 +489,27 @@ func (m *IntPointTxnDefaultServer) Delete(ctx context.Context, in *DeleteIntPoin
 	if db.Error != nil {
 		return nil, db.Error
 	}
+	if custom, ok := interface{}(in).(IntPointTxnIntPointWithBeforeDelete); ok {
+		var err error
+		ctx, db, err = custom.BeforeDelete(ctx, in, db)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &DeleteIntPointResponse{}, DefaultDeleteIntPoint(ctx, &IntPoint{Id: in.GetId()}, db)
 }
 
-type IntPointTxnCustomMethodCustomHandler interface {
-	CustomCustomMethod(context.Context, *google_protobuf2.Empty) (*google_protobuf2.Empty, error)
+// IntPointTxnIntPointWithBeforeDelete called before DefaultCreateIntPoint in the default Create handler
+type IntPointTxnIntPointWithBeforeDelete interface {
+	BeforeDelete(context.Context, *DeleteIntPointRequest, *gorm1.DB) (context.Context, *gorm1.DB, error)
 }
 
 // CustomMethod ...
 func (m *IntPointTxnDefaultServer) CustomMethod(ctx context.Context, in *google_protobuf2.Empty) (*google_protobuf2.Empty, error) {
-	if custom, ok := interface{}(m).(IntPointTxnCustomMethodCustomHandler); ok {
-		return custom.CustomCustomMethod(ctx, in)
-	}
 	return &google_protobuf2.Empty{}, nil
-}
-
-type IntPointTxnCreateSomethingCustomHandler interface {
-	CustomCreateSomething(context.Context, *Something) (*Something, error)
 }
 
 // CreateSomething ...
 func (m *IntPointTxnDefaultServer) CreateSomething(ctx context.Context, in *Something) (*Something, error) {
-	if custom, ok := interface{}(m).(IntPointTxnCreateSomethingCustomHandler); ok {
-		return custom.CustomCreateSomething(ctx, in)
-	}
 	return &Something{}, nil
 }

--- a/plugin/servergen.go
+++ b/plugin/servergen.go
@@ -311,7 +311,7 @@ func (p *OrmPlugin) generatePreserviceCall(svc, typeName, mthd string) {
 }
 
 func (p *OrmPlugin) generatePreserviceHook(svc, typeName, inTypeName, mthd string) {
-	p.P(`// `, svc, typeName, `WithBefore`, mthd, ` called before DefaultCreate`, typeName, ` in the default Create handler`)
+	p.P(`// `, svc, typeName, `WithBefore`, mthd, ` called before Default`, mthd, typeName, ` in the default `, mthd, ` handler`)
 	p.P(`type `, svc, typeName, `WithBefore`, mthd, ` interface {`)
 	p.P(`Before`, mthd, `(context.Context, *`, inTypeName, `, *`, p.Import(gormImport), `.DB) (context.Context, *`, p.Import(gormImport), `.DB, error)`)
 	p.P(`}`)

--- a/plugin/servergen.go
+++ b/plugin/servergen.go
@@ -21,7 +21,6 @@ func (p *OrmPlugin) generateDefaultServer(file *generator.FileDescriptor) {
 			p.P(`}`)
 			for _, method := range service.GetMethod() {
 				methodName := generator.CamelCase(method.GetName())
-				p.generateInterface(service, method)
 				if strings.HasPrefix(methodName, "Create") {
 					p.generateCreateServerMethod(service, method)
 				} else if strings.HasPrefix(methodName, "Read") {
@@ -46,12 +45,14 @@ func (p *OrmPlugin) generateCreateServerMethod(service *descriptor.ServiceDescri
 	follows, typeName := p.followsCreateConventions(inType, outType)
 	if follows {
 		p.generateDBSetup(service, outType)
+		p.generatePreserviceCall(svcName, typeName, "Create")
 		p.P(`res, err := DefaultCreate`, typeName, `(ctx, in.GetPayload(), db)`)
 		p.P(`if err != nil {`)
 		p.P(`return nil, err`)
 		p.P(`}`)
 		p.P(`return &`, p.TypeName(outType), `{Result: res}, nil`)
 		p.P(`}`)
+		p.generatePreserviceHook(svcName, typeName, p.TypeName(inType), "Create")
 	} else {
 		p.generateEmptyBody(outType)
 	}
@@ -90,12 +91,14 @@ func (p *OrmPlugin) generateReadServerMethod(service *descriptor.ServiceDescript
 	follows, typeName := p.followsReadConventions(inType, outType)
 	if follows {
 		p.generateDBSetup(service, outType)
+		p.generatePreserviceCall(svcName, typeName, "Read")
 		p.P(`res, err := DefaultRead`, typeName, `(ctx, &`, typeName, `{Id: in.GetId()}, db)`)
 		p.P(`if err != nil {`)
 		p.P(`return nil, err`)
 		p.P(`}`)
 		p.P(`return &`, p.TypeName(outType), `{Result: res}, nil`)
 		p.P(`}`)
+		p.generatePreserviceHook(svcName, typeName, p.TypeName(inType), "Read")
 	} else {
 		p.generateEmptyBody(outType)
 	}
@@ -133,12 +136,14 @@ func (p *OrmPlugin) generateUpdateServerMethod(service *descriptor.ServiceDescri
 	follows, typeName := p.followsUpdateConventions(inType, outType)
 	if follows {
 		p.generateDBSetup(service, outType)
+		p.generatePreserviceCall(svcName, typeName, "Update")
 		p.P(`res, err := DefaultStrictUpdate`, typeName, `(ctx, in.GetPayload(), db)`)
 		p.P(`if err != nil {`)
 		p.P(`return nil, err`)
 		p.P(`}`)
 		p.P(`return &`, p.TypeName(outType), `{Result: res}, nil`)
 		p.P(`}`)
+		p.generatePreserviceHook(svcName, typeName, p.TypeName(inType), "Update")
 	} else {
 		p.generateEmptyBody(outType)
 	}
@@ -177,8 +182,10 @@ func (p *OrmPlugin) generateDeleteServerMethod(service *descriptor.ServiceDescri
 	follows, typeName := p.followsDeleteConventions(inType, outType, method)
 	if follows {
 		p.generateDBSetup(service, outType)
+		p.generatePreserviceCall(svcName, typeName, "Delete")
 		p.P(`return &`, p.TypeName(outType), `{}, `, `DefaultDelete`, typeName, `(ctx, &`, typeName, `{Id: in.GetId()}, db)`)
 		p.P(`}`)
+		p.generatePreserviceHook(svcName, typeName, p.TypeName(inType), "Delete")
 	} else {
 		p.generateEmptyBody(outType)
 	}
@@ -217,12 +224,14 @@ func (p *OrmPlugin) generateListServerMethod(service *descriptor.ServiceDescript
 	follows, typeName := p.followsListConventions(inType, outType)
 	if follows {
 		p.generateDBSetup(service, outType)
+		p.generatePreserviceCall(svcName, typeName, "List")
 		p.P(`res, err := DefaultList`, typeName, `(ctx, db, in)`)
 		p.P(`if err != nil {`)
 		p.P(`return nil, err`)
 		p.P(`}`)
 		p.P(`return &`, p.TypeName(outType), `{Results: res}, nil`)
 		p.P(`}`)
+		p.generatePreserviceHook(svcName, typeName, p.TypeName(inType), "List")
 	} else {
 		p.generateEmptyBody(outType)
 	}
@@ -247,14 +256,6 @@ func (p *OrmPlugin) followsListConventions(inType generator.Object, outType gene
 	return false, ""
 }
 
-func (p *OrmPlugin) generateInterface(service *descriptor.ServiceDescriptorProto, method *descriptor.MethodDescriptorProto) {
-	inType, outType, methodName, svcName := p.getMethodProps(service, method)
-	p.P(`type `, svcName, methodName, `CustomHandler interface {`)
-	p.P(`Custom`, methodName, `(context.Context, *`, p.TypeName(inType), `) (*`,
-		p.TypeName(outType), `, error)`)
-	p.P(`}`)
-}
-
 func (p *OrmPlugin) generateMethodStub(service *descriptor.ServiceDescriptorProto, method *descriptor.MethodDescriptorProto) {
 	inType, outType, methodName, svcName := p.getMethodProps(service, method)
 	p.generateMethodSignature(inType, outType, methodName, svcName)
@@ -265,9 +266,6 @@ func (p *OrmPlugin) generateMethodSignature(inType, outType generator.Object, me
 	p.P(`// `, methodName, ` ...`)
 	p.P(`func (m *`, svcName, `DefaultServer) `, methodName, ` (ctx context.Context, in *`,
 		p.TypeName(inType), `) (*`, p.TypeName(outType), `, error) {`)
-	p.P(`if custom, ok := interface{}(m).(`, svcName, methodName, `CustomHandler); ok {`)
-	p.P(`return custom.Custom`, methodName, `(ctx, in)`)
-	p.P(`}`)
 }
 
 func (p *OrmPlugin) generateDBSetup(service *descriptor.ServiceDescriptorProto, outType generator.Object) error {
@@ -300,4 +298,21 @@ func (p *OrmPlugin) getMethodProps(service *descriptor.ServiceDescriptorProto,
 	methodName := generator.CamelCase(method.GetName())
 	svcName := generator.CamelCase(service.GetName())
 	return inType, outType, methodName, svcName
+}
+
+func (p *OrmPlugin) generatePreserviceCall(svc, typeName, mthd string) {
+	p.P(`if custom, ok := interface{}(in).(`, svc, typeName, `WithBefore`, mthd, `); ok {`)
+	p.P(`var err error`)
+	p.P(`ctx, db, err = custom.Before`, mthd, `(ctx, in, db)`)
+	p.P(`if err != nil {`)
+	p.P(`return nil, err`)
+	p.P(`}`)
+	p.P(`}`)
+}
+
+func (p *OrmPlugin) generatePreserviceHook(svc, typeName, inTypeName, mthd string) {
+	p.P(`// `, svc, typeName, `WithBefore`, mthd, ` called before DefaultCreate`, typeName, ` in the default Create handler`)
+	p.P(`type `, svc, typeName, `WithBefore`, mthd, ` interface {`)
+	p.P(`Before`, mthd, `(context.Context, *`, inTypeName, `, *`, p.Import(gormImport), `.DB) (context.Context, *`, p.Import(gormImport), `.DB, error)`)
+	p.P(`}`)
 }


### PR DESCRIPTION
Instead of overriding entire autogenerated functions via hook, approach is now to embed the autogenerated server in a new object and override only the necessary functions (also grants access to the autogenerated method).
e.g. 
```
type CustomizedServer {
    GeneratedServer
}
func (cs *CustomizedServer) Create(...) {
    // Do special stuff
    cs.GeneratedServer.Create(...) // if desired, or can override all functionality
}
```

Prehook can be used for altering values in context, adding logging, setting values within the message, etc.