### PR TITLE
Version

### DIFF
--- a/plugin/file.go
+++ b/plugin/file.go
@@ -31,7 +31,7 @@ func (p *OrmPlugin) CleanFiles(response *plugin.CodeGeneratorResponse) {
 			versionString = fmt.Sprintf("// Generated with protoc-gen-gorm version: %s\n", ProtocGenGormVersion)
 		}
 		if AtlasAppToolkitVersion != "" {
-			versionString = fmt.Sprintf("%s// Antipating compatibility with atlas-app-toolkit version: %s\n", versionString, AtlasAppToolkitVersion)
+			versionString = fmt.Sprintf("%s// Anticipating compatibility with atlas-app-toolkit version: %s\n", versionString, AtlasAppToolkitVersion)
 		}
 		file.Content = proto.String(fmt.Sprintf("%s%s%s%s", sections[0], sections[1], versionString, sections[2]))
 	}

--- a/plugin/file.go
+++ b/plugin/file.go
@@ -28,7 +28,7 @@ func (p *OrmPlugin) CleanFiles(response *plugin.CodeGeneratorResponse) {
 		sections := strings.SplitAfterN(file.GetContent(), "\n", 3)
 		versionString := ""
 		if ProtocGenGormVersion != "" {
-			versionString = fmt.Sprintf("// Generated with protoc-gen-gorm version: %s\n", ProtocGenGormVersion)
+			versionString = fmt.Sprintf("\n// Generated with protoc-gen-gorm version: %s\n", ProtocGenGormVersion)
 		}
 		if AtlasAppToolkitVersion != "" {
 			versionString = fmt.Sprintf("%s// Anticipating compatibility with atlas-app-toolkit version: %s\n", versionString, AtlasAppToolkitVersion)

--- a/plugin/file.go
+++ b/plugin/file.go
@@ -1,10 +1,15 @@
 package plugin
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/gogo/protobuf/proto"
 	plugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
+
+var ProtocGenGormVersion string
+var AtlasAppToolkitVersion string
 
 // CleanFiles will prevent generation of any files where no real code is generated
 func (p *OrmPlugin) CleanFiles(response *plugin.CodeGeneratorResponse) {
@@ -19,5 +24,15 @@ func (p *OrmPlugin) CleanFiles(response *plugin.CodeGeneratorResponse) {
 			}
 		}
 		file.Content = CleanImports(file.Content)
+
+		sections := strings.SplitAfterN(file.GetContent(), "\n", 3)
+		versionString := ""
+		if ProtocGenGormVersion != "" {
+			versionString = fmt.Sprintf("// Generated with protoc-gen-gorm version: %s\n", ProtocGenGormVersion)
+		}
+		if AtlasAppToolkitVersion != "" {
+			versionString = fmt.Sprintf("%s// Antipating compatibility with atlas-app-toolkit version: %s\n", versionString, AtlasAppToolkitVersion)
+		}
+		file.Content = proto.String(fmt.Sprintf("%s%s%s%s", sections[0], sections[1], versionString, sections[2]))
 	}
 }


### PR DESCRIPTION
Will output a comment that (can/should) includes the version of protoc-gen-gorm and atlas-app-toolkit. Values must be set at go build/install time. 
A corresponding PR will be made in atlas-gentool to do this. https://github.com/infobloxopen/atlas-gentool/pull/12