### PR TITLE
Fix InetValue marshal/unmarshal quote issues, add better tests

### DIFF
--- a/types/inet.go
+++ b/types/inet.go
@@ -40,6 +40,9 @@ func (i *Inet) Scan(value interface{}) error {
 
 // ParseInet will return the Inet address/netmask represented in the input string
 func ParseInet(addr string) (*Inet, error) {
+	if len(addr) == 0 {
+		return nil, nil
+	}
 	ip, cidr, err := net.ParseCIDR(addr)
 	var mask net.IPMask
 	if err != nil {

--- a/types/types.override.pb.go
+++ b/types/types.override.pb.go
@@ -82,7 +82,7 @@ func (m *InetValue) MarshalJSONPB(*jsonpb.Marshaler) ([]byte, error) {
 	if len(m.Value) == 0 {
 		return []byte("null"), nil
 	}
-	return []byte(m.Value), nil
+	return []byte(fmt.Sprintf(`%q`, m.Value)), nil
 }
 
 // UnmarshalJSONPB overloads InetValue's standard JSON -> PB conversion. If
@@ -92,6 +92,12 @@ func (m *InetValue) UnmarshalJSONPB(_ *jsonpb.Unmarshaler, data []byte) error {
 		m.Value = ""
 		return nil
 	}
-	m.Value = string(data)
+	// Very minimal check for validity, if not a quoted string fails
+	// Additional validation as a valid inet done in conversion to ORM type or
+	// must be performed manually
+	if data[0] != '"' && data[len(data)-1] != '"' {
+		return fmt.Errorf(`invalid inet '%s' does not match accepted format`, data)
+	}
+	m.Value = strings.Trim(string(data), `"`)
 	return nil
 }


### PR DESCRIPTION
Resolves issue where IP Addresses are retaining the quotes from the original JSON and failing to parse during conversion because of this.
Also adds improves handling of the explicitly `null` input case.