### PR TITLE
Minor fix for a case that can cause an import to be missing

### DIFF
--- a/plugin/servergen.go
+++ b/plugin/servergen.go
@@ -444,6 +444,7 @@ func (p *OrmPlugin) generateDBSetup(service autogenService) error {
 	if service.usesTxnMiddleware {
 		p.P(`txn, ok := `, p.Import(tkgormImport), `.FromContext(ctx)`)
 		p.P(`if !ok {`)
+		p.UsingGoImports("errors")
 		p.P(`return nil, errors.New("Database Transaction For Request Missing")`)
 		p.P(`}`)
 		p.P(`db := txn.Begin()`)


### PR DESCRIPTION
If a service with the transaction middleware enabled exists in a file without any formable objects, it will generate a call to `errors.New`, but doesn't import the errors package.