### PR TITLE
types/inet: Handle IPv6 address inside brackets

### DIFF
--- a/types/inet.go
+++ b/types/inet.go
@@ -40,9 +40,14 @@ func (i *Inet) Scan(value interface{}) error {
 
 // ParseInet will return the Inet address/netmask represented in the input string
 func ParseInet(addr string) (*Inet, error) {
-	if len(addr) == 0 {
+	addr_len := len(addr)
+	if addr_len == 0 {
 		return nil, nil
 	}
+	if addr[0] == '[' && addr[addr_len-1] == ']' {
+		addr = addr[1 : addr_len-1]
+	}
+
 	ip, cidr, err := net.ParseCIDR(addr)
 	var mask net.IPMask
 	if err != nil {

--- a/types/inet_test.go
+++ b/types/inet_test.go
@@ -48,6 +48,14 @@ func TestInetParse(t *testing.T) {
 	if !inet.IP.Equal(net.ParseIP("fe80:3::1ff:fe23:4567:890a")) || !reflect.DeepEqual(inet.Mask, net.CIDRMask(128, 128)) {
 		t.Errorf("Did not get expected value, got %+v", *inet)
 	}
+	// ------
+	inet, err = ParseInet("[2000::1]")
+	if err != nil {
+		t.Error(err)
+	}
+	if !inet.IP.Equal(net.ParseIP("2000::1")) || !reflect.DeepEqual(inet.Mask, net.CIDRMask(128, 128)) {
+		t.Errorf("Did not get expected value, got %+v", *inet)
+	}
 }
 
 func TestString(t *testing.T) {


### PR DESCRIPTION
`net.ParseCIDR` fails when IPv6 address given inside brackets:
```
invalid CIDR address: [2000::1]
```

To fix, check for enclosing brackets and remove.