### PR TITLE
Fix for overriding struct when running associations

### DIFF
--- a/example/feature_demo/demo_types.pb.gorm.go
+++ b/example/feature_demo/demo_types.pb.gorm.go
@@ -4047,7 +4047,7 @@ func DefaultStrictUpdateTestAssocHandlerReplace(ctx context.Context, in *TestAss
 			return nil, err
 		}
 	}
-	if err = db.Model(&ormObj).Association("TestTagAssoc").Replace(ormObj.TestTagAssoc).Error; err != nil {
+	if err = db.Model(&TestAssocHandlerReplaceORM{Id: ormObj.Id}).Association("TestTagAssoc").Replace(ormObj.TestTagAssoc).Error; err != nil {
 		return nil, err
 	}
 	ormObj.TestTagAssoc = nil
@@ -4404,7 +4404,7 @@ func DefaultStrictUpdateTestAssocHandlerClear(ctx context.Context, in *TestAssoc
 			return nil, err
 		}
 	}
-	if err = db.Model(&ormObj).Association("TestTagAssoc").Clear().Error; err != nil {
+	if err = db.Model(&TestAssocHandlerClearORM{Id: ormObj.Id}).Association("TestTagAssoc").Clear().Error; err != nil {
 		return nil, err
 	}
 	ormObj.TestTagAssoc = nil
@@ -4761,7 +4761,7 @@ func DefaultStrictUpdateTestAssocHandlerAppend(ctx context.Context, in *TestAsso
 			return nil, err
 		}
 	}
-	if err = db.Model(&ormObj).Association("TestTagAssoc").Append(ormObj.TestTagAssoc).Error; err != nil {
+	if err = db.Model(&TestAssocHandlerAppendORM{Id: ormObj.Id}).Association("TestTagAssoc").Append(ormObj.TestTagAssoc).Error; err != nil {
 		return nil, err
 	}
 	ormObj.TestTagAssoc = nil

--- a/example/user/user.pb.gorm.go
+++ b/example/user/user.pb.gorm.go
@@ -1061,11 +1061,11 @@ func DefaultStrictUpdateUser(ctx context.Context, in *User, db *gorm1.DB) (*User
 	if err = db.Where(filterEmails).Delete(EmailORM{}).Error; err != nil {
 		return nil, err
 	}
-	if err = db.Model(&ormObj).Association("Friends").Replace(ormObj.Friends).Error; err != nil {
+	if err = db.Model(&UserORM{Id: ormObj.Id}).Association("Friends").Replace(ormObj.Friends).Error; err != nil {
 		return nil, err
 	}
 	ormObj.Friends = nil
-	if err = db.Model(&ormObj).Association("Languages").Replace(ormObj.Languages).Error; err != nil {
+	if err = db.Model(&UserORM{Id: ormObj.Id}).Association("Languages").Replace(ormObj.Languages).Error; err != nil {
 		return nil, err
 	}
 	ormObj.Languages = nil


### PR DESCRIPTION
I came across an issue with gorm associations.
I'm not sure if this is new or based on some of the changes that have been going on with gorm

when calling something like 
```
if err = db.Model(&ormObj).Association("Children").Replace(ormObj.Children).Error; err != nil {
  return nil, err
}
```
there is a bonus `select` at the end. this means what ever you were looking at updating is replaced by this select 