### PR TITLE
Fix generateDeleteSetHandler func not to override the primary key name with the column name

### DIFF
--- a/plugin/handlergen.go
+++ b/plugin/handlergen.go
@@ -500,10 +500,6 @@ func (p *OrmPlugin) generateDeleteSetHandler(message *generator.Descriptor) {
 	p.P(`var err error`)
 	ormable := p.getOrmable(typeName)
 	pkName, pk := p.findPrimaryKey(ormable)
-	column := pk.GetTag().GetColumn()
-	if len(column) != 0 {
-		pkName = column
-	}
 	p.P(`keys := []`, pk.Type, `{}`)
 	p.P(`for _, obj := range in {`)
 	p.P(`ormObj, err := obj.ToORM(ctx)`)


### PR DESCRIPTION
When I use such a proto difinition for Host struct
```
message Host {
    option (gorm.opts) = {
        ormable: true,
    };
 int64 legacy_id = 2 [(gorm.field).tag = {primary_key: true, column: "id"}, (atlas_validate.field) = {deny: [update, replace]}];
 atlas.rpc.Identifier id = 1 [(gorm.field) = {reference_of: "Host", tag: {type: "text", column: "id_uuid"}}, (atlas_validate.field) = {deny: [update, replace]}];
}
```
I got the error
```
../../pkg/v2/pb/service/service.pb.gorm.go:2225:12: ormObj.id undefined (type HostORM has no field or method id, but does have Id)
../../pkg/v2/pb/service/service.pb.gorm.go:2228:29: ormObj.id undefined (type HostORM has no field or method id, but does have Id)
```
and got the generated code
```
func DefaultDeleteSaasHostSet(ctx context.Context, in []*SaasHost, db *gorm1.DB) error {
	...
	for _, obj := range in {
		ormObj, err := obj.ToORM(ctx)
		if err != nil {
			return err
		}
		if ormObj.id == 0 {
			return errors1.EmptyIdError
		}
		keys = append(keys, ormObj.id)
	}
	...
}
```
Expected code
```
func DefaultDeleteSaasHostSet(ctx context.Context, in []*SaasHost, db *gorm1.DB) error {
	...
	for _, obj := range in {
		ormObj, err := obj.ToORM(ctx)
		if err != nil {
			return err
		}
		if ormObj.LegacyId == 0 {
			return errors1.EmptyIdError
		}
		keys = append(keys, ormObj.id)
	}
	...
}
```
