### PR TITLE
return DOCKERPATH var, generate-gentool will alwasys fail without it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ gentool:
 
 generate-gentool: SRCROOT_ON_HOST      := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 generate-gentool: SRCROOT_IN_CONTAINER := /go/src/$(PROJECT_ROOT)
+generate-gentool: DOCKERPATH           := /go/src
 generate-gentool: DOCKER_RUNNER        := docker run --rm
 generate-gentool: DOCKER_RUNNER        += -v $(SRCROOT_ON_HOST):$(SRCROOT_IN_CONTAINER)
 generate-gentool: DOCKER_GENERATOR     := infoblox/atlas-gentool:dev-gengorm


### PR DESCRIPTION
example feature_demo/demo_types.proto is still broken, maybe after
recent changes

protoc-gen-gogo: error:Cannot include Array field into TestTypesORM as it aready exists there.