### PR TITLE
Add go type transformation for any not caught in initial if-else clause

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -921,6 +921,12 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 			} else {
 				continue
 			}
+		} else {
+			goType, pointer := fieldGoType(g, field)
+			if pointer {
+				goType = "*" + goType
+			}
+			fieldType = goType
 		}
 
 		switch fieldType {
@@ -965,6 +971,49 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 			panic("cound not include")
 		}
 	}
+}
+
+func fieldGoType(g *protogen.GeneratedFile, field *protogen.Field) (goType string, pointer bool) {
+	if field.Desc.IsWeak() {
+		return "struct{}", false
+	}
+
+	pointer = field.Desc.HasPresence()
+	switch field.Desc.Kind() {
+	case protoreflect.BoolKind:
+		goType = "bool"
+	case protoreflect.EnumKind:
+		goType = g.QualifiedGoIdent(field.Enum.GoIdent)
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		goType = "int32"
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		goType = "uint32"
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		goType = "int64"
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		goType = "uint64"
+	case protoreflect.FloatKind:
+		goType = "float32"
+	case protoreflect.DoubleKind:
+		goType = "float64"
+	case protoreflect.StringKind:
+		goType = "string"
+	case protoreflect.BytesKind:
+		goType = "[]byte"
+		pointer = false // rely on nullability of slices for presence
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		goType = "*" + g.QualifiedGoIdent(field.Message.GoIdent)
+		pointer = false // pointer captured as part of the type
+	}
+	switch {
+	case field.Desc.IsList():
+		return "[]" + goType, false
+	case field.Desc.IsMap():
+		keyType, _ := fieldGoType(g, field.Message.Fields[0])
+		valType, _ := fieldGoType(g, field.Message.Fields[1])
+		return fmt.Sprintf("map[%v]%v", keyType, valType), false
+	}
+	return goType, pointer
 }
 
 func (b *ORMBuilder) addIncludedField(ormable *OrmableType, field *gorm.ExtraField, g *protogen.GeneratedFile) {


### PR DESCRIPTION
Ran into an issue where `byte` types in proto were not being translated correctly when the go gorm file was being created. Realized there was a variety of proto types that were not being taken into account in the if-else clause converting the types. Added a final catch at the end to leverage similar logic the [protoc-gen-go](https://github.com/golang/protobuf/tree/master/protoc-gen-go) plugin ([cmd/protoc-gen-go/internal_gengo/main.go#L632](https://github.com/protocolbuffers/protobuf-go/blob/master/cmd/protoc-gen-go/internal_gengo/main.go#L632)) uses to convert to go types. 