### PR TITLE
fixes a nil pointer dereference crash and adds backward compatibility for proto import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,48 @@ The generated code can also integrate with the grpc server gorm transaction midd
 in the [atlas-app-toolkit](https://github.com/infobloxopen/atlas-app-toolkit#middlewares)
 using the service level option `option (gorm.server).txn_middleware = true`.
 
+### Proto Import Paths
+
+The proto definition files are located in the `proto/` directory:
+- `proto/options/gorm.proto` - GORM options for messages, fields, and services
+- `proto/types/types.proto` - Custom wrapper types (UUID, JSON, Inet, etc.)
+
+#### Using with Buf
+
+If you're using [buf](https://buf.build/), you can use short import paths:
+
+```protobuf
+import "options/gorm.proto";
+import "types/types.proto";
+```
+
+Configure your `buf.work.yaml` to include the protoc-gen-gorm proto directory, or add it as a dependency in your `buf.yaml`.
+
+#### Using with protoc
+
+When using `protoc` directly, use the full import paths and add the proto directory to your include path:
+
+```protobuf
+import "github.com/infobloxopen/protoc-gen-gorm/proto/options/gorm.proto";
+import "github.com/infobloxopen/protoc-gen-gorm/proto/types/types.proto";
+```
+
+Then include the path when running protoc:
+```bash
+protoc -I. -I$GOPATH/src/github.com/infobloxopen/protoc-gen-gorm/proto ...
+```
+
+#### Migration from Legacy Import Paths
+
+If you are upgrading from an older version of protoc-gen-gorm that used the following import paths:
+
+| Old Path | New Path |
+|----------|----------|
+| `github.com/infobloxopen/protoc-gen-gorm/options/gorm.proto` | `github.com/infobloxopen/protoc-gen-gorm/proto/options/gorm.proto` |
+| `github.com/infobloxopen/protoc-gen-gorm/types/types.proto` | `github.com/infobloxopen/protoc-gen-gorm/proto/types/types.proto` |
+
+**Backward Compatibility:** Symlinks have been added at the old paths (`options/gorm.proto` and `types/types.proto`) that point to the new locations, so existing proto files using the old import paths will continue to work.
+
 ### Examples
 
 Example .proto files and generated .pb.gorm.go files are included in the

--- a/options/gorm.proto
+++ b/options/gorm.proto
@@ -1,0 +1,1 @@
+../proto/options/gorm.proto

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3105,7 +3105,8 @@ func (b *ORMBuilder) followsUpdateSetConventions(inType *protogen.Message, outTy
 			inEntity = field
 		}
 
-		if string(field.Desc.Message().FullName()) == "google.protobuf.FieldMask" {
+		// Add nil check to prevent panic when field is not a message type
+		if field.Desc.Message() != nil && string(field.Desc.Message().FullName()) == "google.protobuf.FieldMask" {
 			if inFieldMask != nil {
 				fmt.Fprintf(os.Stderr, "message must not contains double field mask, prev on field name %s, after on field %s.\n", inFieldMask.GoName, field.GoName)
 				return false, "", ""
@@ -3167,7 +3168,8 @@ func (b *ORMBuilder) followsUpdateConventions(inType *protogen.Message, outType 
 		}
 
 		// Check that type of field is a FieldMask
-		if string(field.Desc.Message().FullName()) == "google.protobuf.FieldMask" {
+		// Add nil check to prevent panic when field is not a message type
+		if field.Desc.Message() != nil && string(field.Desc.Message().FullName()) == "google.protobuf.FieldMask" {
 			// More than one mask in request is not allowed.
 			if updateMask != "" {
 				return false, "", ""
@@ -3183,7 +3185,7 @@ func (b *ORMBuilder) followsUpdateConventions(inType *protogen.Message, outType 
 
 	var outTypeName string
 	for _, field := range outType.Fields {
-		if string(field.Desc.Name()) == "result" {
+		if string(field.Desc.Name()) == "result" && field.Desc.Message() != nil {
 			gType := string(field.Desc.Message().Name())
 			outTypeName = strings.TrimPrefix(gType, "*")
 		}

--- a/types/types.proto
+++ b/types/types.proto
@@ -1,0 +1,1 @@
+../proto/types/types.proto


### PR DESCRIPTION
## Summary

This PR fixes a nil pointer dereference crash and adds backward compatibility for proto import paths.

## Changes

### 1. Bug Fix: Nil Pointer Dereference in Plugin

Fixed crash that occurred when processing proto files with non-message field types (e.g., primitive types like `int32`, `string`).

**Affected functions in `plugin/plugin.go`:**
- `followsUpdateConventions()` - Added nil checks at lines 3171 and 3189
- `followsUpdateSetConventions()` - Added nil check at line 3109

2. Proto Import Path Backward Compatibility
Added symlinks to support both old and new proto import paths:

// Both paths now work
import "github.com/infobloxopen/protoc-gen-gorm/options/gorm.proto";       // old
import "github.com/infobloxopen/protoc-gen-gorm/proto/options/gorm.proto"; // new